### PR TITLE
Escape non-US-ASCII characters in `SassException.toCssString()`

### DIFF
--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -82,12 +82,12 @@ class SassException extends SourceSpanException {
         .replaceAll("\r\n", "\n");
     term_glyph.ascii = wasAscii;
 
-    // For the string comment, render all non-ASCII characters as escape
+    // For the string comment, render all non-US-ASCII characters as escape
     // sequences so that they'll show up even if the HTTP headers are set
     // incorrectly.
     var stringMessage = StringBuffer();
     for (var rune in SassString(toString(color: false)).toString().runes) {
-      if (rune > 0xFF) {
+      if (rune > 0x7F) {
         stringMessage
           ..writeCharCode($backslash)
           ..write(rune.toRadixString(16))


### PR DESCRIPTION
Currently `SassException.toCssString()` would write code points between 128 and 255 in UTF-8. The result cannot be parsed as US-ASCII (ASCII-7BIT) and will be parsed incorrectly as Extended ASCII (ASCII-8BIT).

UTF-8 encoded file with only code points less than 128 is completely interchangeable with US-ASCII. Therefore, this PR further escapes code points between 128 and 255. 